### PR TITLE
Make profile an optional argument

### DIFF
--- a/windows/win_firewall_rule.ps1
+++ b/windows/win_firewall_rule.ps1
@@ -120,17 +120,19 @@ function createFireWallRule ($fwsettings) {
     $execString="netsh advfirewall firewall add rule "
 
     ForEach ($fwsetting in $fwsettings.GetEnumerator()) {
-        if ($fwsetting.key -eq 'Direction') {
-            $key='dir'
-        } else {
-            $key=$($fwsetting.key).ToLower()
-        };
-        $execString+=" ";
-        $execString+=$key;
-        $execString+="=";
-        $execString+='"';
-        $execString+=$fwsetting.value;
-        $execString+='"';
+        if ($fwsetting.value -ne "") {
+            if ($fwsetting.key -eq 'Direction') {
+                $key='dir'
+            } else {
+                $key=$($fwsetting.key).ToLower()
+            };
+            $execString+=" ";
+            $execString+=$key;
+            $execString+="=";
+            $execString+='"';
+            $execString+=$fwsetting.value;
+            $execString+='"';
+        }
     };
     try {
         #$msg+=@($execString);
@@ -262,7 +264,7 @@ foreach ($arg in $args){
     };
 };
 
-$winprofile=Get-Attr $params "profile" "current";
+$winprofile=Get-Attr $params "profile" "";
 $fwsettings.Add("profile", $winprofile)
 
 if ($misArg){

--- a/windows/win_firewall_rule.ps1
+++ b/windows/win_firewall_rule.ps1
@@ -132,7 +132,7 @@ function createFireWallRule ($fwsettings) {
             $execString+='"';
             $execString+=$fwsetting.value;
             $execString+='"';
-        }
+        };
     };
     try {
         #$msg+=@($execString);


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

 win_firewall_rile
##### Ansible Version:

```
ansible 2.0.0.2
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Currently ansible use command with default profile `current` to create a firewall rule, and this command has error:

```
One or more of the specified profiles is  not valid. 'Any' cannot be specified if other profiles are specified.
```

After this patch firewall rules can be created on azure virtual machine.
